### PR TITLE
fix: broken github edit base url

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -36,9 +36,9 @@ const config = {
           path: "../nitro/docs/",
           sidebarPath: require.resolve("./sidebars.js"),
           routeBasePath: "/",
-          editUrl: function(s) {
+          editUrl: function (s) {
             return (
-              "https://github.com/OffchainLabs/nitro/tree/docs/docs/" +
+              "https://github.com/OffchainLabs/nitro/edit/master/docs/" +
               s.docPath
             );
           }


### PR DESCRIPTION
I wanted to edit a page on the docs but the "edit this page" link was broken

e.g.
https://developer.arbitrum.io/getting-started-users

Tested this fix locally.