### PR TITLE
chore: gen sdk docs in yarn start

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "cd ../arbitrum-sdk && yarn && yarn generate_docs && cd ../website && docusaurus start",
     "build": "cd ../arbitrum-sdk && yarn && yarn generate_docs && cd ../website && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
As mentioned on https://github.com/OffchainLabs/nitro-docs/pull/3#discussion_r963454228

https://github.com/OffchainLabs/nitro-docs/blob/b2775f6f313ead3adc9269ee959749a7a78a4419/website/package.json#L8

we can have the start script do similar thing as the build script e.g.
```
"start": "cd ../arbitrum-sdk && yarn && yarn generate_docs && cd ../website && docusaurus start",
```

_Originally posted by @gzeoneth in https://github.com/OffchainLabs/nitro-docs/pull/3#discussion_r963454228_